### PR TITLE
Add ankipandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ A curated list of awesome [Anki](https://github.com/dae/anki) add-ons, decks and
 
 * [kerrickstaley/genanki ![GitHub stars](https://img.shields.io/github/stars/kerrickstaley/genanki.svg)](https://github.com/kerrickstaley/genanki) - Python library for generating Anki decks.
 
+* [klieret/AnkiPandas ![GitHub stars](https://img.shields.io/github/stars/klieret/AnkiPandas.svg)](https://github.com/klieret/AnkiPandas) - Python library for analysing and manipulating Anki decks using pandas dataframes.
+
 * [Archenoth/clj-anki ![GitHub stars](https://img.shields.io/github/stars/Archenoth/clj-anki.svg)](https://github.com/Archenoth/clj-anki) - Clojure Anki-file interaction library to read and write `*.anki2` and `*.apkg` files.
 
 * [flimzy/anki ![GitHub stars](https://img.shields.io/github/stars/flimzy/anki.svg)](https://github.com/flimzy/anki) - Go library to read Anki `*.apkg` files.


### PR DESCRIPTION
See issue #41 by me:

> [AnkiPandas](https://github.com/klieret/AnkiPandas) by @klieret allows analyzing Anki-cards with the popular pandas python package for tabular data analysis and it also allows modifying the database. I'm a bit biased because I know the dev, but it has 89 stars and still seems objectively developed, so I think it deserves being included in this list.

Resolves #41